### PR TITLE
Remove redundant Transactional on updateExisting

### DIFF
--- a/src/main/java/ru/krotarnya/diasync/repository/DataPointRepositoryImpl.java
+++ b/src/main/java/ru/krotarnya/diasync/repository/DataPointRepositoryImpl.java
@@ -49,7 +49,6 @@ public class DataPointRepositoryImpl implements DataPointRepositoryCustom {
         return Optional.of(jpa.save(updated));
     }
 
-    @Transactional
     protected DataPoint updateExisting(DataPoint existingPoint, DataPoint newPoint) {
         DataPoint updated = newPoint.toBuilder()
                 .id(existingPoint.getId())


### PR DESCRIPTION
## Summary
- clean up DataPointRepositoryImpl by removing method-level `@Transactional` from `updateExisting`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_684187e300fc832688b09ef9ee21bbc6